### PR TITLE
Mention: agent gradients, grouped lists, avatars

### DIFF
--- a/packages/neuphlo-editor/package.json
+++ b/packages/neuphlo-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuphlo-editor",
-  "version": "2.3.1",
+  "version": "2.4.2",
   "private": false,
   "description": "A lightweight React wrapper around Tiptap with sensible defaults and image upload support.",
   "type": "module",

--- a/packages/neuphlo-editor/src/headless/extensions/Mention/mention-command.tsx
+++ b/packages/neuphlo-editor/src/headless/extensions/Mention/mention-command.tsx
@@ -1,6 +1,38 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import type { MentionItem } from "./mention"
 
+const GRADIENT_MAP: Record<string, string> = {
+  red: "linear-gradient(135deg, #ef4444, #fb7185)",
+  coral: "linear-gradient(135deg, #f87171, #fb923c)",
+  orange: "linear-gradient(135deg, #f97316, #fbbf24)",
+  amber: "linear-gradient(135deg, #f59e0b, #facc15)",
+  lime: "linear-gradient(135deg, #84cc16, #4ade80)",
+  green: "linear-gradient(135deg, #10b981, #2dd4bf)",
+  teal: "linear-gradient(135deg, #14b8a6, #22d3ee)",
+  cyan: "linear-gradient(135deg, #06b6d4, #60a5fa)",
+  blue: "linear-gradient(135deg, #3b82f6, #818cf8)",
+  indigo: "linear-gradient(135deg, #6366f1, #a78bfa)",
+  violet: "linear-gradient(135deg, #8b5cf6, #a855f7)",
+  purple: "linear-gradient(135deg, #a855f7, #d946ef)",
+  fuchsia: "linear-gradient(135deg, #d946ef, #f472b6)",
+  pink: "linear-gradient(135deg, #ec4899, #fb7185)",
+  slate: "linear-gradient(135deg, #64748b, #71717a)",
+  stone: "linear-gradient(135deg, #78716c, #a3a3a3)",
+}
+
+function isGradientKey(avatar?: string): boolean {
+  return !!avatar && avatar in GRADIENT_MAP
+}
+
+function isAgentItem(item: MentionItem): boolean {
+  return !!item.email?.endsWith("@ai.neuphlo.local")
+}
+
+function getInitials(name: string): string {
+  if (!name) return "AG"
+  return name.split(/\s+/).map((w: string) => w[0]).join("").slice(0, 2).toUpperCase()
+}
+
 interface MentionCommandProps {
   items: MentionItem[]
   command: (item: MentionItem) => void
@@ -8,7 +40,9 @@ interface MentionCommandProps {
 }
 
 // Simple Avatar component with inline styles
-function Avatar({ src, fallback }: { src?: string; fallback: string }) {
+function Avatar({ src, fallback, isAgent }: { src?: string; fallback: string; isAgent?: boolean }) {
+  const gradient = src && isGradientKey(src) ? GRADIENT_MAP[src] : isAgent ? GRADIENT_MAP.violet : null
+
   return (
     <div style={{
       position: "relative",
@@ -19,7 +53,22 @@ function Avatar({ src, fallback }: { src?: string; fallback: string }) {
       overflow: "hidden",
       borderRadius: "9999px",
     }}>
-      {src ? (
+      {gradient ? (
+        <div style={{
+          display: "flex",
+          height: "100%",
+          width: "100%",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: "9999px",
+          background: gradient,
+          color: "#ffffff",
+          fontSize: "10px",
+          fontWeight: 600,
+        }}>
+          {fallback}
+        </div>
+      ) : src ? (
         <img
           style={{
             aspectRatio: "1",
@@ -135,48 +184,70 @@ export const MentionCommand = forwardRef<any, MentionCommandProps>((props, ref) 
       }}
     >
       {props.items.length ? (
-        props.items.map((item, index) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => selectItem(index)}
-            onMouseEnter={() => setSelectedIndex(index)}
-            style={{
-              position: "relative",
-              display: "flex",
-              width: "100%",
-              cursor: "default",
-              userSelect: "none",
-              alignItems: "center",
-              gap: "8px",
-              borderRadius: "4px",
-              padding: "10px 8px",
-              fontSize: "14px",
-              outline: "none",
-              backgroundColor: index === selectedIndex ? "var(--accent)" : "transparent",
-              color: index === selectedIndex ? "var(--accent-foreground)" : "inherit",
-              border: "none",
-              textAlign: "left",
-            }}
-          >
-            {item.type ? (
-              <ReferenceIcon type={item.type} />
-            ) : (
-              <Avatar
-                src={item.avatar}
-                fallback={item.label.slice(0, 2).toUpperCase()}
-              />
-            )}
-            <span style={{
-              flex: 1,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}>
-              {item.label}
-            </span>
-          </button>
-        ))
+        (() => {
+          const agents = props.items.filter(i => !i.type && isAgentItem(i))
+          const others = props.items.filter(i => i.type || !isAgentItem(i))
+          const sections: Array<{ label: string | null; items: typeof props.items; startIndex: number }> = []
+          if (agents.length) sections.push({ label: "Agents", items: agents, startIndex: 0 })
+          if (others.length) sections.push({ label: agents.length ? "Members" : null, items: others, startIndex: agents.length })
+
+          return sections.map((section) => (
+            <div key={section.label ?? "default"}>
+              {section.label && (
+                <div style={{ padding: "6px 8px 2px", fontSize: "11px", fontWeight: 600, color: "var(--muted-foreground)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                  {section.label}
+                </div>
+              )}
+              {section.items.map((item, i) => {
+                const index = section.startIndex + i
+                const agent = isAgentItem(item)
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => selectItem(index)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    style={{
+                      position: "relative",
+                      display: "flex",
+                      width: "100%",
+                      cursor: "default",
+                      userSelect: "none",
+                      alignItems: "center",
+                      gap: "8px",
+                      borderRadius: "4px",
+                      padding: "10px 8px",
+                      fontSize: "14px",
+                      outline: "none",
+                      backgroundColor: index === selectedIndex ? "var(--accent)" : "transparent",
+                      color: index === selectedIndex ? "var(--accent-foreground)" : "inherit",
+                      border: "none",
+                      textAlign: "left",
+                    }}
+                  >
+                    {item.type ? (
+                      <ReferenceIcon type={item.type} />
+                    ) : (
+                      <Avatar
+                        src={item.avatar}
+                        fallback={getInitials(item.label)}
+                        isAgent={agent}
+                      />
+                    )}
+                    <span style={{
+                      flex: 1,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}>
+                      {item.label}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          ))
+        })()
       ) : (
         <div style={{
           padding: "24px 0",

--- a/packages/neuphlo-editor/src/headless/extensions/Mention/mention-list.tsx
+++ b/packages/neuphlo-editor/src/headless/extensions/Mention/mention-list.tsx
@@ -1,6 +1,43 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import type { MentionItem } from "./mention"
 
+// Gradient map for agent avatars (avatar field stores a gradient key like "violet")
+const GRADIENT_MAP: Record<string, string> = {
+  red: "linear-gradient(135deg, #ef4444, #fb7185)",
+  coral: "linear-gradient(135deg, #f87171, #fb923c)",
+  orange: "linear-gradient(135deg, #f97316, #fbbf24)",
+  amber: "linear-gradient(135deg, #f59e0b, #facc15)",
+  lime: "linear-gradient(135deg, #84cc16, #4ade80)",
+  green: "linear-gradient(135deg, #10b981, #2dd4bf)",
+  teal: "linear-gradient(135deg, #14b8a6, #22d3ee)",
+  cyan: "linear-gradient(135deg, #06b6d4, #60a5fa)",
+  blue: "linear-gradient(135deg, #3b82f6, #818cf8)",
+  indigo: "linear-gradient(135deg, #6366f1, #a78bfa)",
+  violet: "linear-gradient(135deg, #8b5cf6, #a855f7)",
+  purple: "linear-gradient(135deg, #a855f7, #d946ef)",
+  fuchsia: "linear-gradient(135deg, #d946ef, #f472b6)",
+  pink: "linear-gradient(135deg, #ec4899, #fb7185)",
+  slate: "linear-gradient(135deg, #64748b, #71717a)",
+  stone: "linear-gradient(135deg, #78716c, #a3a3a3)",
+}
+
+function isAgent(item: { email?: string }): boolean {
+  return !!item.email?.endsWith("@ai.neuphlo.local")
+}
+
+function isGradientKey(avatar?: string): boolean {
+  return !!avatar && avatar in GRADIENT_MAP
+}
+
+function getAgentGradient(item: { avatar?: string }): string {
+  return GRADIENT_MAP[item.avatar || "violet"] || GRADIENT_MAP.violet
+}
+
+function getInitials(name: string): string {
+  if (!name) return "AG"
+  return name.split(/\s+/).map(w => w[0]).join("").slice(0, 2).toUpperCase()
+}
+
 interface MentionListProps {
   items: MentionItem[]
   command: (item: MentionItem) => void
@@ -67,88 +104,123 @@ export const MentionList = forwardRef<any, MentionListProps>((props, ref) => {
       }}
     >
       {props.items.length ? (
-        props.items.map((item, index) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => selectItem(index)}
-            className="nph-mention-item"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
-              width: "100%",
-              padding: "8px",
-              border: "none",
-              borderRadius: "6px",
-              background: index === selectedIndex ? "#f1f5f9" : "transparent",
-              cursor: "pointer",
-              textAlign: "left",
-              transition: "background 0.15s",
-            }}
-            onMouseEnter={() => setSelectedIndex(index)}
-          >
-            {/* Avatar */}
-            {item.avatar ? (
-              <img
-                src={item.avatar}
-                alt={item.label}
-                style={{
-                  width: "24px",
-                  height: "24px",
-                  borderRadius: "50%",
-                  objectFit: "cover",
-                }}
-              />
-            ) : (
-              <div
-                style={{
-                  width: "24px",
-                  height: "24px",
-                  borderRadius: "50%",
-                  background: "#e2e8f0",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontSize: "10px",
-                  fontWeight: "600",
-                  color: "#64748b",
-                }}
-              >
-                {item.label.slice(0, 2).toUpperCase()}
-              </div>
-            )}
+        (() => {
+          const agents = props.items.filter(i => isAgent(i))
+          const members = props.items.filter(i => !isAgent(i))
+          const sections: Array<{ label: string; items: typeof props.items; startIndex: number }> = []
+          if (agents.length) sections.push({ label: "Agents", items: agents, startIndex: 0 })
+          if (members.length) sections.push({ label: "Members", items: members, startIndex: agents.length })
 
-            {/* Name and optional email */}
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div
-                style={{
-                  fontSize: "14px",
-                  fontWeight: "500",
-                  color: "#0f172a",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {item.label}
+          return sections.map((section) => (
+            <div key={section.label}>
+              <div style={{ padding: "6px 8px 4px", fontSize: "11px", fontWeight: "600", color: "#94a3b8", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                {section.label}
               </div>
-              {item.email && (
-                <div
-                  style={{
-                    fontSize: "12px",
-                    color: "#64748b",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {item.email}
-                </div>
-              )}
+              {section.items.map((item, i) => {
+                const index = section.startIndex + i
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => selectItem(index)}
+                    className="nph-mention-item"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                      width: "100%",
+                      padding: "8px",
+                      border: "none",
+                      borderRadius: "6px",
+                      background: index === selectedIndex ? "#f1f5f9" : "transparent",
+                      cursor: "pointer",
+                      textAlign: "left",
+                      transition: "background 0.15s",
+                    }}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                  >
+                    {/* Avatar */}
+                    {(isGradientKey(item.avatar) || isAgent(item)) ? (
+                      <div
+                        style={{
+                          width: "24px",
+                          height: "24px",
+                          borderRadius: "50%",
+                          background: getAgentGradient(item),
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontSize: "10px",
+                          fontWeight: "600",
+                          color: "#ffffff",
+                        }}
+                      >
+                        {getInitials(item.label)}
+                      </div>
+                    ) : item.avatar ? (
+                      <img
+                        src={item.avatar}
+                        alt={item.label}
+                        style={{
+                          width: "24px",
+                          height: "24px",
+                          borderRadius: "50%",
+                          objectFit: "cover",
+                        }}
+                      />
+                    ) : (
+                      <div
+                        style={{
+                          width: "24px",
+                          height: "24px",
+                          borderRadius: "50%",
+                          background: "#e2e8f0",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontSize: "10px",
+                          fontWeight: "600",
+                          color: "#64748b",
+                        }}
+                      >
+                        {item.label.slice(0, 2).toUpperCase()}
+                      </div>
+                    )}
+
+                    {/* Name and optional email */}
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div
+                        style={{
+                          fontSize: "14px",
+                          fontWeight: "500",
+                          color: "#0f172a",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {item.label}
+                      </div>
+                      {item.email && !isAgent(item) && (
+                        <div
+                          style={{
+                            fontSize: "12px",
+                            color: "#64748b",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {item.email}
+                        </div>
+                      )}
+                    </div>
+                  </button>
+                )
+              })}
             </div>
-          </button>
-        ))
+          ))
+        })()
       ) : (
         <div
           style={{

--- a/packages/neuphlo-editor/src/headless/extensions/Mention/mention-node-view.tsx
+++ b/packages/neuphlo-editor/src/headless/extensions/Mention/mention-node-view.tsx
@@ -1,6 +1,25 @@
 import { NodeViewWrapper } from "@tiptap/react"
 import type { NodeViewProps } from "@tiptap/react"
 
+const GRADIENT_MAP: Record<string, string> = {
+  red: "linear-gradient(135deg, #ef4444, #fb7185)",
+  coral: "linear-gradient(135deg, #f87171, #fb923c)",
+  orange: "linear-gradient(135deg, #f97316, #fbbf24)",
+  amber: "linear-gradient(135deg, #f59e0b, #facc15)",
+  lime: "linear-gradient(135deg, #84cc16, #4ade80)",
+  green: "linear-gradient(135deg, #10b981, #2dd4bf)",
+  teal: "linear-gradient(135deg, #14b8a6, #22d3ee)",
+  cyan: "linear-gradient(135deg, #06b6d4, #60a5fa)",
+  blue: "linear-gradient(135deg, #3b82f6, #818cf8)",
+  indigo: "linear-gradient(135deg, #6366f1, #a78bfa)",
+  violet: "linear-gradient(135deg, #8b5cf6, #a855f7)",
+  purple: "linear-gradient(135deg, #a855f7, #d946ef)",
+  fuchsia: "linear-gradient(135deg, #d946ef, #f472b6)",
+  pink: "linear-gradient(135deg, #ec4899, #fb7185)",
+  slate: "linear-gradient(135deg, #64748b, #71717a)",
+  stone: "linear-gradient(135deg, #78716c, #a3a3a3)",
+}
+
 // Icon components
 function NodeIcon() {
   return (
@@ -74,7 +93,26 @@ export const MentionNodeView = (props: NodeViewProps) => {
       {isArticle && <ArticleIcon />}
 
       {/* Show avatar for user mentions */}
-      {!isReference && avatar && (
+      {!isReference && avatar && avatar in GRADIENT_MAP && (
+        <div
+          style={{
+            width: "20px",
+            height: "20px",
+            borderRadius: "50%",
+            background: GRADIENT_MAP[avatar],
+            color: "#ffffff",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: "8px",
+            fontWeight: 600,
+            flexShrink: 0,
+          }}
+        >
+          {(label || id).split(/\s+/).map((w: string) => w[0]).join("").slice(0, 2).toUpperCase()}
+        </div>
+      )}
+      {!isReference && avatar && !(avatar in GRADIENT_MAP) && (
         <img
           src={avatar}
           alt={label || id}

--- a/packages/neuphlo-editor/src/headless/extensions/Mention/mention.tsx
+++ b/packages/neuphlo-editor/src/headless/extensions/Mention/mention.tsx
@@ -152,6 +152,7 @@ export const createMentionExtension = (options?: MentionOptions) => {
                 slug: item.slug,
               },
             },
+            { type: "text", text: " " },
           ])
           .run()
       },


### PR DESCRIPTION
Bump package version to 2.4.2 and enhance the Mention extension: add a shared GRADIENT_MAP for agent avatar gradients, detect agent items (emails ending with @ai.neuphlo.local), and render initials with gradient backgrounds as fallbacks. Group mention results into "Agents" and "Members" sections in both the command and list UI, improve Avatar component styling, and show gradient initials in the node view when avatar keys map to gradients. Also insert a trailing space after inserting a mention to ensure proper spacing in the editor.